### PR TITLE
Support receiving tweets in original format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ var GnipStream = function(options) {
 		self.emit('object', object);
 		if (object.error) self.emit('error', new Error('Stream response error: ' + (object.error.message || '-')));
 		else if (object.verb == 'delete') self.emit('delete', object.id);
-		else if (object.body) self.emit('tweet', object);
+		else if (object.body || object.text) self.emit('tweet', object);
 	});
 	self.parser.on('error', function(err) {
 		self.emit('error', err);


### PR DESCRIPTION
Fix to emit "tweet" when the "Leave data in its original format" option has been checked for the stream