### PR TITLE
Handle Connection Timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Currenly, this module only supports JSON activity stream format, so you must ena
 # Gnip.Stream
 This class is an EventEmitter and allows you to connect to the stream and start receiving data.
 
+## Constructor options
+
+#### options.timeout
+As requested in the Gnip docs (http://support.gnip.com/apis/powertrack/api_reference.html), this option in the constructor allows us to set a read timeout in the client. The recommended a value is >=30 seconds, so the constructor will throw an error if a smaller timeout is provided. The default value for this option is 35 seconds.
+
+
 ## API methods
 
 #### stream.start()

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,7 @@ GnipStream.prototype.start = function() {
 	if (self.options.debug) util.log('Starting stream...');
 	
 	if (!self.options.url) throw new Error('Invalid end point specified!');
+  if (self.options.timeout && self.options.timeout <= 30000) throw new Error('Timeout must be beyond 30s');
 	
 	if (self._req) self.end();
 	

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,6 +111,15 @@ GnipStream.prototype.start = function() {
 			self.emit('ready');
 		}
 	});
+  
+  self._req.on('socket', function(socket) {
+    socket.setTimeout(self.options.timeout || 35000);
+    socket.on('timeout', function() {
+      self.emit('error', new Error('Connection Timeout'));
+      self.end();
+    })
+  });
+
 	self._req.on('error', function(err) {
 		self.emit('error', err);
 		self.end();

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ GnipStream.prototype.start = function() {
 	if (self.options.debug) util.log('Starting stream...');
 	
 	if (!self.options.url) throw new Error('Invalid end point specified!');
-  if (self.options.timeout && self.options.timeout <= 30000) throw new Error('Timeout must be beyond 30s');
+  	if (self.options.timeout && self.options.timeout <= 30000) throw new Error('Timeout must be beyond 30s');
 	
 	if (self._req) self.end();
 	
@@ -113,13 +113,13 @@ GnipStream.prototype.start = function() {
 		}
 	});
   
-  self._req.on('socket', function(socket) {
-    socket.setTimeout(self.options.timeout || 35000);
-    socket.on('timeout', function() {
-      self.emit('error', new Error('Connection Timeout'));
-      self.end();
-    })
-  });
+	self._req.on('socket', function(socket) {
+		socket.setTimeout(self.options.timeout || 35000);
+		socket.on('timeout', function() {
+		  self.emit('error', new Error('Connection Timeout'));
+		  self.end();
+		})
+	});
 
 	self._req.on('error', function(err) {
 		self.emit('error', err);


### PR DESCRIPTION
As requested in the Gnip docs (http://support.gnip.com/apis/powertrack/api_reference.html), we should be able to set a read timeout in the client (recommended a value beyond 30 seconds).

This PR enables this by setting properly the timeout and raising and error event (ending the connection) if the socket triggers the timeout event. 
I have set the default to be 35s and a validation in the start method to throw an Error if the timeout provided is <= 30s