### PR TITLE
Delete object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ var GnipStream = function(options) {
 	self.parser.on('object', function(object) {
 		self.emit('object', object);
 		if (object.error) self.emit('error', new Error('Stream response error: ' + (object.error.message || '-')));
-		else if (object.verb == 'delete') self.emit('delete', object.object);
+		else if (object.verb == 'delete') self.emit('delete', object);
 		else if (object.body) self.emit('tweet', object);
 	});
 	self.parser.on('error', function(err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ var GnipStream = function(options) {
 	self.parser.on('object', function(object) {
 		self.emit('object', object);
 		if (object.error) self.emit('error', new Error('Stream response error: ' + (object.error.message || '-')));
-		else if (object.verb == 'delete') self.emit('delete', object.id);
+		else if (object.verb == 'delete') self.emit('delete', object.object);
 		else if (object.body) self.emit('tweet', object);
 	});
 	self.parser.on('error', function(err) {


### PR DESCRIPTION
The "delete" event tries to emit object.id which is undefined since the Gnip compliance firehose. This update will emit the full object which looks like this:

```
{ objectType: 'activity',
  verb: 'delete',
  object: { id: 'tag:search.twitter.com,2005:628700331719946249' },
  actor: { id: 'id:twitter.com:752960479' },
  timestampMs: '2015-10-05T17:14:05.926+00:00' }
```