### PR TITLE
Implemented support for powertrack 2.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,14 +9,14 @@ var EventEmitter = require('events').EventEmitter,
 
 /**
  * Connects to Gnip streaming api and tracks keywords.
- * 
+ *
  * @param options Object with the following properties:
  *  - (String) user
  *  - (String) password
  *  - (String) userAgent
  *  - (String) url
  *  - (Boolean) debug
- *  
+ *
  * Events:
  * - data: function(String data) {...}
  * - object: function(Object object) {...}
@@ -28,9 +28,9 @@ var EventEmitter = require('events').EventEmitter,
  */
 var GnipStream = function(options) {
 	EventEmitter.call(this);
-	
+
 	var self = this;
-	
+
 	self.options = _.extend({
 		user : '',
 		password : '',
@@ -38,9 +38,9 @@ var GnipStream = function(options) {
 		url : null,
 		debug : false
 	}, options || {});
-	
+
 	self._req = null;
-	
+
 	self.parser = new JSONParser();
 	self.parser.on('object', function(object) {
 		self.emit('object', object);
@@ -57,21 +57,21 @@ util.inherits(GnipStream, EventEmitter);
 
 GnipStream.prototype.start = function() {
 	var self = this;
-	
+
 	if (self.options.debug) util.log('Starting stream...');
-	
+
 	if (!self.options.url) throw new Error('Invalid end point specified!');
   	if (self.options.timeout && self.options.timeout <= 30000) throw new Error('Timeout must be beyond 30s');
-	
+
 	if (self._req) self.end();
-	
+
 	var streamUrl = require('url').parse(self.options.url);
-	var headers = {	
+	var headers = {
 		'Accept-Encoding' : 'gzip',
 		'Connection' : 'keep-alive'
 	};
 	if (self.options.userAgent) headers['User-Agent'] = self.options.userAgent;
-	
+
 	var options = {
 		host : streamUrl.hostname,
 		port : streamUrl.port,
@@ -79,14 +79,15 @@ GnipStream.prototype.start = function() {
 		qs   : self.options.client? {client: self.options.client} : undefined,
 		headers : headers,
 		auth : self.options.user + ':' + self.options.password,
-		agent : false
+		agent : false,
+		version : 1
 	};
-	
+
 	if (self.options.debug) {
 		util.log('Http options:');
 		console.log(options);
 	}
-	
+
 	var gunzip = zlib.createGunzip();
 	gunzip.on('data', function(data) {
 		self.parser.receive(data);
@@ -95,7 +96,7 @@ GnipStream.prototype.start = function() {
 	gunzip.on('error', function(err) {
 		self.emit('error', err);
 	});
-	
+
 	self._req = https.get(options, function(res) {
 		res.pipe(gunzip);
 		res.on('error', function(err) {
@@ -113,7 +114,7 @@ GnipStream.prototype.start = function() {
 			self.emit('ready');
 		}
 	});
-  
+
 	self._req.on('socket', function(socket) {
 		socket.setTimeout(self.options.timeout || 35000);
 		socket.on('timeout', function() {
@@ -128,7 +129,7 @@ GnipStream.prototype.start = function() {
 	});
 	self._req.end();
 };
-	
+
 GnipStream.prototype.end = function() {
 	if (this._req) {
 		this._req.abort();

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -4,9 +4,10 @@ var request = require('request'),
 	fs = require('fs'),
 	async = require('async');
 
-var LiveRules = function(endPoint, user, password) {
+var LiveRules = function(endPoint, user, password, version) {
 	this._api = endPoint;
 	this._auth = "Basic " + new Buffer(user + ':' + password).toString('base64');
+	this._version = version;
 };
 
 /**
@@ -46,8 +47,10 @@ LiveRules.prototype.remove = function(rules, cb) {
 			return (typeof rule == 'string') ? {value: rule} : rule;
 		})
 	};
-	request.del({
-		url : this._api,
+	var url = this._version === 1 ? this._api : this._api + '?_method=delete';
+	var method = this._version === 1 ? 'del' : 'post';
+	request[method]({
+		url : url,
 		json: json,
 		headers : {'Authorization' : this._auth}
 	}, function(err, response, body) {
@@ -116,13 +119,14 @@ var GnipRules = function(options) {
 		password : '',
 		url : null,
 		debug : false,
-		batchSize: 5000
+		batchSize: 5000,
+		version: 1
 	}, options || {});
 
 	this._api = this.options.url;
 	this._auth = "Basic " + new Buffer(this.options.user + ':' + this.options.password).toString('base64');
 	this._cacheFile = __dirname + '/' + crypto.createHash('md5').update(this._api).digest('hex') + '.cache';
-	this.live = new LiveRules(this._api, this.options.user, this.options.password);
+	this.live = new LiveRules(this._api, this.options.user, this.options.password, this.options.version);
 
 	if (!fs.existsSync(this._cacheFile)) {
 		fs.writeFileSync(this._cacheFile, '[]', 'utf8');


### PR DESCRIPTION
I implemented support for [PowerTrack 2.0](http://support.gnip.com/apis/powertrack2.0/). The only change needed (apart from different urls via config) seems to be the API to delete rules. 

I introduced the 'version' option in GnipStream, GnipRules and LiveRules , which defaults to 1 so not to break any existing code. If you set it to 2 you can use the 2.0 API. 