### PR TITLE
Fixed GnipRules removeAll bug

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -102,9 +102,14 @@ LiveRules.prototype.getAll = function(cb) {
 LiveRules.prototype.removeAll = function(cb) {
 	var self = this;
 	self.getAll(function(err, rules) {
-		if (err) cb(err);
-		else self.remove(rules, cb);
-	});
+    if (err) {
+      cb(err);
+    } else if (rules.length > 0) {
+      self.remove(rules, cb);
+    } else {
+      cb(null);
+    }
+  });
 };
 
 


### PR DESCRIPTION
For example if you have cleared all rules using the [GNIP Console](https://console.gnip.com) and then call `removeAll()`, the call to `getAll()` will return nothing, and then at least with the 2.0 API you will get an error if you pass an empty array when removing rules. 