### PR TITLE
Fix for vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=0.8"
   },
   "dependencies": {
-    "request": "2.9.x",
+    "request": "2.74.0",
     "async": "0.1.x",
     "underscore": "1.3.x"
   },


### PR DESCRIPTION
gnip currently has a 1 vulnerable dependency paths, introducing 1 different types of known vulnerabilities.

This PR fixes vulnerable dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/demian85/gnip) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Stay Secure,
The Snyk Team
