### PR TITLE
Added ability to pass the 'bucket' parameter, for counts queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ The maximum number of search results to be returned by a request. A number betwe
 #### options.tag
 Used to segregate rules and their matching data into different logical groups. Optional.
 
+#### options.bucket
+The unit of time for which count data will be provided. Options: "day", "hour", "minute". Optional, for /counts calls.
+
 ## API methods
 
 #### stream.start()
@@ -232,6 +235,20 @@ Example Usage
 	search.on('end', function(err) {
 		if( err ) 
 			console.error(err);
+	});
+	
+	// search counts usage
+	var counts = new Gnip.Search({
+		url : 'https://gnip-stream.twitter.com/stream/powertrack/accounts/xxx/publishers/twitter/prod/counts.json',
+		user : 'xxx',
+		password : 'xxx',
+		query : '@user',
+		bucket: 'day'
+	});
+	
+	counts.on('object', function(object) {
+		console.log(object.results);
+		counts.end();
 	});
 	
 More details and tests soon...

--- a/lib/search.js
+++ b/lib/search.js
@@ -125,6 +125,9 @@ GnipSearch.prototype._makeRequest = function( next, callback )
 	if( this.options.tag )
 		requestParameters.tag = this.options.tag;
 
+	if( this.options.bucket )
+		requestParameters.bucket = this.options.bucket.toLowerCase();
+
 	if( next )
 		requestParameters.next = next;
 


### PR DESCRIPTION
This is sort of a "quick" feature addition, so that queries to the search `counts` endpoint work with the existing streaming infrastructure of the Search API within the code.

The only parameter that is necessary is the `bucket` parameter, which was added in this PR.

Everything works as with the normal search calls. Note that due to how the counts endpoint does not page, users should always end the stream on the `object` event.

Thanks!