### PR TITLE
Enable overriding the parser used within the Rules API

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ Emitted when the connection is terminated. This event is always emitted when an 
 # Gnip.Rules
 This class allows you to manage an unlimited number of tracking rules.
 
+## Constructor options
+
+#### options.user
+GNIP account username.
+
+#### options.password
+GNIP account password.
+
+#### options.url
+GNIP Rules endpoint url e.g. `https://gnip-api.twitter.com/rules/${streamType}/accounts/${account}/publishers/twitter/${label}.json`
+
+#### options.batchSize
+The batch size used when adding/deleting rules in bulk. (Defaults to 5000)
+
+#### options.parser
+Much like the `parser` option allowed in the [Gnip Stream](https://github.com/demian85/gnip#gnipstream) constructor, you can pass a custom parser handler/library for incoming JSON data. This is optional, and defaults to the native `JSON` parser. [More details](https://github.com/demian85/gnip#optionsparser).
+
 ## API methods
 
 #### rules.getAll(Function callback)
@@ -180,6 +197,7 @@ Installation
 Example Usage
 ====
 	var Gnip = require('gnip');
+	var JSONBigInt = require('json-bigint');
 
 	var stream = new Gnip.Stream({
 		url : 'https://gnip-stream.twitter.com/stream/powertrack/accounts/xxx/publishers/twitter/prod.json',
@@ -202,6 +220,7 @@ Example Usage
 		user : 'xxx',
 		password : 'xxx',
 		batchSize: 1234, // not required, defaults to 5000
+		parser: JSONBigInt // required in order to properly parse large integral rule IDs
 	});
 
 	var newRules = [

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -4,9 +4,10 @@ var request = require('request'),
 	fs = require('fs'),
 	async = require('async');
 
-var LiveRules = function(endPoint, user, password) {
+var LiveRules = function(endPoint, user, password, parser) {
 	this._api = endPoint;
 	this._auth = "Basic " + new Buffer(user + ':' + password).toString('base64');
+	this.parser = parser;
 };
 
 /**
@@ -83,7 +84,7 @@ LiveRules.prototype.getAll = function(cb) {
 		if (err) cb(err);
 		else if (response.statusCode >= 200 && response.statusCode < 300) {
 			try {
-				var rules = JSON.parse(body).rules;
+				var rules = self.parser.parse(body).rules;
 				cb(null, rules);
 			} catch(e) {
 				cb(e);
@@ -121,13 +122,14 @@ var GnipRules = function(options) {
 		password : '',
 		url : null,
 		debug : false,
-		batchSize: 5000
+		batchSize: 5000,
+		parser: JSON
 	}, options || {});
 
 	this._api = this.options.url;
 	this._auth = "Basic " + new Buffer(this.options.user + ':' + this.options.password).toString('base64');
 	this._cacheFile = __dirname + '/' + crypto.createHash('md5').update(this._api).digest('hex') + '.cache';
-	this.live = new LiveRules(this._api, this.options.user, this.options.password);
+	this.live = new LiveRules(this._api, this.options.user, this.options.password, this.options.parser);
 
 	if (!fs.existsSync(this._cacheFile)) {
 		fs.writeFileSync(this._cacheFile, '[]', 'utf8');
@@ -161,11 +163,12 @@ GnipRules.prototype._addRulesBatch = function(rules, max, cb) {
 };
 
 GnipRules.prototype.getAll = function(cb) {
+	var self = this;
 	fs.readFile(this._cacheFile, 'utf8', function(err, contents) {
 		if (err) cb(err);
 		else {
 			try {
-				cb(null, JSON.parse(contents));
+				cb(null, self.parser.parse(contents));
 			} catch (e) {
 				cb(null, []);
 			}
@@ -190,7 +193,7 @@ GnipRules.prototype.update = function(rules, cb) {
 		else {
 			var currentRules;
 			try {
-				currentRules = JSON.parse(contents);
+				currentRules = self.parser.parse(contents);
 			} catch (e) {
 				currentRules = [];
 			}
@@ -219,7 +222,7 @@ GnipRules.prototype.update = function(rules, cb) {
 					self._addRulesBatch(addRules, self.options.batchSize, cb);
 				},
 				function(cb) {
-					fs.writeFile(self._cacheFile, JSON.stringify(rules), 'utf8', cb);
+					fs.writeFile(self._cacheFile, self.parser.stringify(rules), 'utf8', cb);
 				}
 			], function(err) {
 				if (err) cb(err);


### PR DESCRIPTION
This is primarily driven to support swapping in `json-bigint` for rule IDs, which currently are not parsed correctly when using the native `JSON` parser.