### PR TITLE
take rule.tag into account

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -181,6 +181,13 @@ GnipRules.prototype.clearCache = function (cb) {
   fs.writeFile(this._cacheFile, '[]', 'utf8', cb);
 };
 
+function getRuleKey(rule) {
+  if (rule.tag) {
+    return rule.value + ' tag: ' + rule.tag;
+  }
+  return rule.value;
+}
+
 GnipRules.prototype.update = function (rules, cb) {
 
   var self = this;
@@ -201,18 +208,18 @@ GnipRules.prototype.update = function (rules, cb) {
 
       // which rules to delete?
       var rulesPlain = rules.map(function (rule) {
-        return rule.value;
+        return getRuleKey(rule);
       });
       var deleteRules = currentRules.filter(function (rule) {
-        return rulesPlain.indexOf(rule.value) == -1;
+        return rulesPlain.indexOf(getRuleKey(rule)) == -1;
       });
 
       // which rules to add?
       var currentRulesPlain = currentRules.map(function (rule) {
-        return rule.value;
+        return getRuleKey(rule);
       });
       var addRules = rules.filter(function (rule) {
-        return currentRulesPlain.indexOf(rule.value) == -1;
+        return currentRulesPlain.indexOf(getRuleKey(rule)) == -1;
       });
 
       async.series([


### PR DESCRIPTION
Hello!
A few days ago we started using tags in GNIP rules and I found (which I think is) a bug in the library:

If I want to change the tag of a rule (same value), this library doesn't detect the changes and so it doesn't update the rule.
AFAIK, rule tags cannot be changed in GNIP API. If you want to update a rule tag you have tu delete the rule and create a new one.

Code Examples:

```
gnip = require('gnip');
rules = new gnip.Rules({ url:'url', user:'me', password:'secret' });

// Works great!
rules.clearCache(() => {
  rules.update(['hi','bye'], console.log); // Two rules are created
});

// Still works great!
rules.clearCache(() => {
  rules.update([{ value: 'hi' },{ value: 'bye' }], console.log);
});

// Still works great! and creates the rules with tags
rules.clearCache(() => {
  rules.update([
    { tag: 'r1', value: 'hi' },
    { tag: 'r2', value: 'bye' },
  ], console.log);
});

// Now I just want to update the tag of an existing rule
rules.clearCache(() => {
  const rules1 = [
    { tag: 'r1', value: 'hi' },
    { tag: 'r2', value: 'bye' },
  ];
  const rules2 = [
    { tag: 'newTag', value: 'hi' }, // same value, different tag
    { tag: 'r2', value: 'bye' },
  ];
  rules.update(rules1, () => { // rules1 are created with their tags
    // Previously nothing happened in the next update. With this new fix 
    // the rule: { tag: 'r1', value: 'hi' } is deleted
    // and the rule: { tag: 'newTag', value: 'hi' } is added
    // because the match is not based in the rule.value but the combination of
    // rule.value and rule.tag
    rules.update(rules2, console.log);
  });
});
```