### PR TITLE
Add support for getting rules based on their GNIP IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Clears cached rules.
 #### rules.live.add(Array rules, Function callback)
 #### rules.live.remove(Array rules, Function callback)
 #### rules.live.getAll(Function callback)
+#### rules.live.getByIds(Array ids, Function callback)
 #### rules.live.removeAll(Function callback)
 
 # Gnip.Search

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -98,6 +98,35 @@ LiveRules.prototype.getAll = function (cb) {
 };
 
 /**
+* Get rules matching GNIP IDs
+* @param ids List of strings
+* @param cb Function callback
+*/
+LiveRules.prototype.getByIds = function (ids, cb) {
+  var self = this;
+  var json = {
+    rule_ids: ids
+  };
+  request.post({
+    url: self._api + '?_method=get',
+    json: json,
+    headers: { 'Authorization': self._auth }
+  }, function (err, response, body) {
+    if (err) cb(err);
+    else if (response.statusCode >= 200 && response.statusCode < 300) {
+      try {
+        cb(null, body.rules);
+      } catch (e) {
+        cb(e);
+      }
+    }
+    else {
+      cb(new Error('Unable to fetch rules. Request failed with status code: ' + response.statusCode));
+    }
+  });
+};
+
+/**
 * Remove current tracking rules
 * @param cb Function callback
 */

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 var Gnip = require('./lib/index');
 var async = require('async');
+var _ = require('underscore');
 
 var stream = new Gnip.Stream({
   url: 'https://stream.gnip.com:443/accounts/xxx/publishers/twitter/streams/track/dev.json',
@@ -35,7 +36,8 @@ rules.live.removeAll(function (err) {
     async.series([
       async.apply(test, ['ford', 'peugeot']),
       async.apply(test, ['peugeot']),
-      async.apply(test, ['volkswagen', 'audi', { value: 'ferrari' }])
+      async.apply(test, ['volkswagen', 'audi', { value: 'ferrari' }]),
+      async.apply(testGetRulesByIds)
     ], function (err) {
       if (err) throw err;
     });
@@ -66,5 +68,26 @@ function test(r, cb) {
         })
       }
     ], cb);
+  });
+}
+
+function testGetRulesByIds(cb) {
+  console.log('Testing get rules by id...');
+
+  rules.live.getAll(function (err, allRules) {
+    if (err) throw err;
+
+    if (_.isEmpty(allRules)) {
+      console.log('Could not execute test because no rules exist');
+      return cb();
+    }
+
+    var ids = [allRules[0].id];
+    rules.live.getByIds(ids, function (err, rules) {
+      if (err) throw err;
+      console.log('Live rules by id:');
+      console.log(rules);
+      cb();
+    });
   });
 }


### PR DESCRIPTION
Adding support for getting a list of rules by their GNIP IDs:

http://support.gnip.com/apis/powertrack2.0/api_reference.html#GetRules

I'm only adding live support as caching would require a bit of rewriting on how the cache is written and how keys are stored.

Please let me know if you'd rather I move out the test for getting by ID to a separate file! :)