### PR TITLE
Clean up unnecessary try/catch in getByIds

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -114,11 +114,7 @@ LiveRules.prototype.getByIds = function (ids, cb) {
   }, function (err, response, body) {
     if (err) cb(err);
     else if (response.statusCode >= 200 && response.statusCode < 300) {
-      try {
-        cb(null, body.rules);
-      } catch (e) {
-        cb(e);
-      }
+      cb(null, body.rules);
     }
     else {
       cb(new Error('Unable to fetch rules. Request failed with status code: ' + response.statusCode));


### PR DESCRIPTION
Per previous discussion, removing try/catch around getting rules from body since we are not doing any processing on the body.