### PR TITLE
Add tried rules info on update error

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -31,6 +31,7 @@ LiveRules.prototype.add = function (rules, cb) {
     else if (response.statusCode >= 200 && response.statusCode < 300) cb(null, body);
     else {
       var errStr = 'Unable to add rules. Request failed with status code: ' + response.statusCode;
+      errStr += '.\n' + JSON.stringify(json);
       if (body && body.error) errStr += '.\n' + body.error.message;
       cb(new Error(errStr));
     }
@@ -55,7 +56,12 @@ LiveRules.prototype.remove = function (rules, cb) {
   }, function (err, response, body) {
     if (err) cb(err);
     else if (response.statusCode >= 200 && response.statusCode < 300) cb(null, body);
-    else cb(new Error('Unable to delete rules. Request failed with status code: ' + response.statusCode));
+    else {
+      var errStr = 'Unable to delete rules. Request failed with status code: ' + response.statusCode;
+      errStr += '.\n' + JSON.stringify(json);
+      if (body && body.error) errStr += '.\n' + body.error.message;
+      cb(new Error(errStr));
+    }
   });
 };
 


### PR DESCRIPTION
Hello!
I'm sending this PR to solve a problem I'm having now, but I'm not 100% sure that this should be the right way to do it. Maybe we can discuss it in the PR and I can modify it with your fedback.

The situation:

* Let's say I have many gnip rules. `const allRules=[...]; // allRules.length ~10k`
* Whenever some rules change, I call `rules.update(allRules)`
* A rule is malformed and `rules.update()` returns an error in the callback because it cannot be added. All I receive is `Error: Unable to add rules. Request failed with status code: 422`

The Problem:
* I dont know what rule(s) changed to debug the problem or automatically update the configuration that caused the error.
* Right now, to find the problematic rules I'm forced to duplicate the logic to split `rulesPlain` into `addRules ` and `deleteRules` out of the library, which is not ideal.

Returning the `error` + the intended changes would fix the situation.

I also considered changing somehow the `error` or the `error.message` to include this information, but I found it more intrusive since someone else could be relying on a specific returned `error`.

Thanks!

