### PR TITLE
Added the ability to set a custom cacheFile for GnipRules

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ GNIP Rules endpoint url e.g. `https://gnip-api.twitter.com/rules/${streamType}/a
 The batch size used when adding/deleting rules in bulk. (Defaults to 5000)
 - `parser`
 Much like the `parser` option allowed in the [Gnip Stream](https://github.com/demian85/gnip#gnipstream) constructor, you can pass a custom parser handler/library for incoming JSON data. This is optional, and defaults to the [json-bigint](https://www.npmjs.com/package/json-bigint) library. [More details](https://github.com/demian85/gnip#optionsparser).
+- `cacheFile`
+Internally `Gnip.Rules` uses a file for caching the current state of the rules configuration, the default path is in the directory of the package. This optional configuration allows you to change the path as the default one may cause problems in applications where `node_modules` is in a read-only filesystems (e.g. AWS Lambda).
 
 ## API methods
 

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -168,12 +168,13 @@ var GnipRules = function (options) {
     url: null,
     debug: false,
     batchSize: 5000,
-    parser: JSONBigInt
+    parser: JSONBigInt,
+    cacheFile: null
   }, options || {});
 
   this._api = this.options.url;
   this._auth = "Basic " + new Buffer(this.options.user + ':' + this.options.password).toString('base64');
-  this._cacheFile = __dirname + '/' + crypto.createHash('md5').update(this._api).digest('hex') + '.cache';
+  this._cacheFile = this.options.cacheFile || __dirname + '/' + crypto.createHash('md5').update(this._api).digest('hex') + '.cache';
   this.live = new LiveRules(this._api, this.options.user, this.options.password, this.options.parser);
 
   if (!fs.existsSync(this._cacheFile)) {


### PR DESCRIPTION
We're running `gnip` on AWS Lambda where `node_modules` is in a read-only filesystem which throws the following error upon creating a new instance of `Gnip.Rules`:

    EROFS: read-only file system, open '/var/task/node_modules/gnip/lib/[FILENAME REDACTED].cache'

This PR allows you to pass a `cacheFile` configuration option to `Gnip.Rules` with a custom file path instead of the default.