### PR TITLE
Fix/rules parsing

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -30,23 +30,30 @@ function formatFailedRules (body) {
  * @param cb Function callback
  */
 LiveRules.prototype.add = function (rules, cb) {
-  var json = {
+  var self = this;
+  var body = {
     rules: rules.map(function (rule) {
       return (typeof rule == 'string') ? { value: rule } : rule;
     })
   };
   request.post({
     url: this._api,
-    json: json,
-    headers: { 'Authorization': this._auth }
+    body: self.parser.stringify(body),
+    json: false,
+    headers: {
+      'Authorization': this._auth,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }
   }, function (err, response, body) {
     if (err) cb(err);
-    else if (response.statusCode >= 200 && response.statusCode < 300) cb(null, body);
+    else if (response.statusCode >= 200 && response.statusCode < 300) cb(null, self.parser.parse(body));
     else {
+      var parsedBody = self.parser.parse(body);
       var errStr = 'Unable to add rules. Request failed with status code: ' + response.statusCode;
-      var ruleErrors = formatFailedRules(body);
+      var ruleErrors = formatFailedRules(parsedBody);
       if (ruleErrors) errStr += '\n' + ruleErrors;
-      if (body && body.error) errStr += '\n' + body.error.message;
+      if (parsedBody && parsedBody.error) errStr += '\n' + parsedBody.error.message;
       cb(new Error(errStr));
     }
   });
@@ -58,21 +65,28 @@ LiveRules.prototype.add = function (rules, cb) {
  * @param cb Function callback
  */
 LiveRules.prototype.remove = function (rules, cb) {
-  var json = {
+  var self = this;
+  var body = {
     rules: rules.map(function (rule) {
       return (typeof rule == 'string') ? { value: rule } : rule;
     })
   };
   request.post({
     url: this._api + '?_method=delete',
-    json: json,
-    headers: { 'Authorization': this._auth }
+    body: self.parser.stringify(body),
+    json: false,
+    headers: {
+      'Authorization': this._auth,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }
   }, function (err, response, body) {
     if (err) cb(err);
-    else if (response.statusCode >= 200 && response.statusCode < 300) cb(null, body);
+    else if (response.statusCode >= 200 && response.statusCode < 300) cb(null, self.parser.parse(body));
     else {
+      var parsedBody = self.parser.parse(body);
       var errStr = 'Unable to delete rules. Request failed with status code: ' + response.statusCode;
-      if (body && body.error) errStr += '\n' + body.error.message;
+      if (parsedBody && parsedBody.error) errStr += '\n' + parsedBody.error.message;
       cb(new Error(errStr));
     }
   });
@@ -99,7 +113,8 @@ LiveRules.prototype.getAll = function (cb) {
   var self = this;
   request({
     url: self._api,
-    headers: { 'Authorization': self._auth }
+    headers: { 'Authorization': self._auth },
+    json: false
   }, function (err, response, body) {
     if (err) cb(err);
     else if (response.statusCode >= 200 && response.statusCode < 300) {
@@ -123,17 +138,22 @@ LiveRules.prototype.getAll = function (cb) {
 */
 LiveRules.prototype.getByIds = function (ids, cb) {
   var self = this;
-  var json = {
+  var body = {
     rule_ids: ids
   };
   request.post({
     url: self._api + '?_method=get',
-    json: json,
-    headers: { 'Authorization': self._auth }
+    body: self.parser.stringify(body),
+    json: false,
+    headers: {
+      'Authorization': self._auth,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }
   }, function (err, response, body) {
     if (err) cb(err);
     else if (response.statusCode >= 200 && response.statusCode < 300) {
-      cb(null, body.rules);
+      cb(null, self.parser.parse(body).rules);
     }
     else {
       cb(new Error('Unable to fetch rules. Request failed with status code: ' + response.statusCode));

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -8,6 +8,11 @@ var JSONBigInt = require('json-bigint');
 var LiveRules = function (endPoint, user, password, parser) {
   this._api = endPoint;
   this._auth = "Basic " + new Buffer(user + ':' + password).toString('base64');
+  this._headers = {
+    'Authorization': this._auth,
+    'Content-Type': 'application/json',
+    'Accept': 'application/json'
+  };
   this.parser = parser;
 };
 
@@ -40,11 +45,7 @@ LiveRules.prototype.add = function (rules, cb) {
     url: this._api,
     body: self.parser.stringify(body),
     json: false,
-    headers: {
-      'Authorization': this._auth,
-      'Content-Type': 'application/json',
-      'Accept': 'application/json'
-    }
+    headers: this._headers,
   }, function (err, response, body) {
     if (err) cb(err);
     else if (response.statusCode >= 200 && response.statusCode < 300) cb(null, self.parser.parse(body));
@@ -75,11 +76,7 @@ LiveRules.prototype.remove = function (rules, cb) {
     url: this._api + '?_method=delete',
     body: self.parser.stringify(body),
     json: false,
-    headers: {
-      'Authorization': this._auth,
-      'Content-Type': 'application/json',
-      'Accept': 'application/json'
-    }
+    headers: this._headers,
   }, function (err, response, body) {
     if (err) cb(err);
     else if (response.statusCode >= 200 && response.statusCode < 300) cb(null, self.parser.parse(body));
@@ -113,8 +110,8 @@ LiveRules.prototype.getAll = function (cb) {
   var self = this;
   request({
     url: self._api,
-    headers: { 'Authorization': self._auth },
-    json: false
+    json: false,
+    headers: this._headers
   }, function (err, response, body) {
     if (err) cb(err);
     else if (response.statusCode >= 200 && response.statusCode < 300) {
@@ -145,11 +142,7 @@ LiveRules.prototype.getByIds = function (ids, cb) {
     url: self._api + '?_method=get',
     body: self.parser.stringify(body),
     json: false,
-    headers: {
-      'Authorization': self._auth,
-      'Content-Type': 'application/json',
-      'Accept': 'application/json'
-    }
+    headers: this._headers,
   }, function (err, response, body) {
     if (err) cb(err);
     else if (response.statusCode >= 200 && response.statusCode < 300) {


### PR DESCRIPTION
2 commits:

fix: use constructed JSON parser on rules responses to properly parse ids

    If the request library is provided a JSON body on POST, it will
    automatically parse the response using JSON.parse. However, this
    will incorrectly decode the id field. This change uses parser.parse
    (defaults to JSONBigInt) to ensure that the id is properly decoded.

refactor: pull up headers to an instance variable